### PR TITLE
rework of for-loop - idx as own variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ The supported variable names (can be changed at the beginning of the zero_functi
 ## Seq and arrays
 
 All supported methods work on finite indexable types and arrays.
-For `array[A, T]` we return `array[A, T]` and we try to not do any additional allocations.
-For other types we return seq
+If a handler returns a collection, it will be the same shape as the input one for seq-s and arrays
+and seq for other collections(e.g. array.map returns an array). 
+You can always get a seq if you use `<handler>Seq` e.g. mapSeq.
 
 We can describe the supported types as
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zero-functional
 
-[![Build Status](https://travis-ci.org/alehander42/zero-functional.svg?branch=master)](https://travis-ci.org/alehander42/zero-functional)
+[![Build Status](https://travis-ci.org/alehander42/zero-functional.svg?branch=rework-iterator)](https://travis-ci.org/alehander42/zero-functional)
 
 A library providing (almost) zero-cost chaining for functional abstractions in Nim.
 
@@ -86,15 +86,17 @@ it's still very experimental, but it shows such an purely metaprogramming approa
 The supported variable names (can be changed at the beginning of the zero_functional.nim file) are:
 
 * `it` is used for the iterator variable
-* `a` is used as the accumulator in fold
-
+* `idx` is used as integer index of current iteration
+* `a` is used as the accumulator in `fold`
+* `c` is used as combination element in `combinations`
 
 ## Seq and arrays
 
 All supported methods work on finite indexable types and arrays.
-If a handler returns a collection, it will be the same shape as the input one for seq-s and arrays
-and seq for other collections(e.g. array.map returns an array). 
-You can always get a seq if you use `<handler>Seq` e.g. mapSeq.
+If a handler returns a collection, it will be the same shape as the input one for seq-s, arrays and DoublyLinkedList-s.
+Other collections are mapped to seq if it cannot be automatically converted. (e.g. array.map returns an array). 
+You can always get a seq if you use `<handler>Seq` e.g. `mapSeq` - or `to(seq)`.
+Some of the supported methods default to seq-output, e.g. map when changing the result type, flatten and indexedMap.
 
 We can describe the supported types as
 
@@ -135,12 +137,13 @@ The methods work with auto it variable
 ```nim
 sequence --> map(op)
 ```
-Map each item in the list to a new value.
+Map each item in the list to a new value. 
 Example:
 ```nim
 let x = @[1,2,3] --> map(it * 2)
 check(x == @[2,4,6])
 ```
+Map also supports converting the type of iterator item and thus of the list.
 
 ### filter
 
@@ -211,16 +214,95 @@ the sequtils `a` is `_`, `a` is `it`
 var n = zip(a, b) --> map(it[0] + it[1]).fold(0, a + it)
 ```
 
+## reduce
+
+Same as fold, but with the iterator converted to a tuple where
+`it[0]` is the current result and `it[1]` the actual iterator on the list.
+
+```nim
+var n = a --> reduce(it[0] + it[1])
+```
+
 ### foreach
 
 Can only be used with functions that have side effects.
 When last command in the chain the result is void. 
-As in-between element, the code is simply executed on each element. 
+As in-between element, the code is simply executed on each element.
+The iterator content may be changed in foreach resulting in changing
+the original list.
 
 ```nim
 @[1,2,3] --> 
     foreach(echo($it))
+    
+var a = @[1,2,3]
+a --> foreach(it = it * 2)
+check (a == @[2,4,6]
 ```
+
+### flatten
+
+Working on a collection of iterable items, the flatten function flattens out the elements of the list.
+
+```nim
+check(@[@[1,2], @[3,4]] --> flatten() == @[1,2,3,4])
+```
+
+### combinations
+
+Combines each element with each other - the resulting variable is `c` with `c.it` as array of 2 containing the combined
+iterator values and `c.idx` containg their indices.
+Combinatiions is not allowed as last argument.
+
+```nim
+# find the indices of the elements in the list, where the diff to the other element is 1
+check(@[11,2,7,3,4] --> combinations() --> filter(abs(c.it[1]-c.it[0]) == 1) --> map(c.idx) == @[[1,3],[3,4]])
+#          ^   ^ ^
+```
+
+### to
+
+Finally it is possible to force the result type to the type given in `to` - which is only allowed as last argument.
+This method is handled differently from the others and removed internally so the command before `to` is the actual last argument. 
+
+When the result type is given as `seq`, `array` or `list` (the latter is mapped to `DoublyLinkedList`) then the template argument
+will be determined automatically.
+However when all auto-detection fails, the result type may be given explicitly here.
+
+```nim
+check([1,2,3]) --> to(seq) == @[1,2,3])
+var l = @[1,2,3] --> map($it) --> to(list)
+let l2: DoublyLinkedList[string] = l
+echo(l2)
+```
+
+## Overview Table
+
+Result type depends on the function used as last parameter.
+
+| Command       | 1st Param | in-between | Last Param | Result Type                 |
+| ------------- | --------- | ---------- | ---------- | --------------------------- | 
+|all            |           |            |     +      | bool                        |
+|combinations   |   +       |     +      |            | N/A                         |
+|exists         |           |            |     +      | bool                        |
+|filter         |   +       |     +      |     +      | part list / zeroed array    |
+|find           |           |            |     +      | int                         |
+|flatten        |   +       |     +      |     +      | list                        |
+|fold           |           |            |     +      | *                           |
+|foreach        |   +       |     +      |     +      | void                        |
+|index          |           |            |     +      | int                         |
+|indexedMap     |   +       |     +      |     +      | seq[(int,*)]                |
+|map            |   +       |     +      |     +      | orig[*]                     |
+|reduce         |           |            |     +      | *                           |
+|sub            |   +       |     +      |     +      | part list / zeroed array    |
+|zip            |   +       |            |            | seq[(*,..,*)]               |
+|to             |           |            |   virtual  | given type                  |
+
+*: any type depending on given function parameters
+list: is any input-list type
+orig: is the original list type
+to: is a "virtual" function, can only be given as last argument, but does not count as last argument.
+
 
 ### LICENSE
 

--- a/README.md
+++ b/README.md
@@ -298,10 +298,10 @@ Result type depends on the function used as last parameter.
 |zip            |   +       |            |            | seq[(*,..,*)]               |
 |to             |           |            |   virtual  | given type                  |
 
-*: any type depending on given function parameters
-list: is any input-list type
-orig: is the original list type
-to: is a "virtual" function, can only be given as last argument, but does not count as last argument.
++ *: any type depending on given function parameters
++ list: is any input-list type
++ orig: is the original list type
++ to: is a "virtual" function, can only be given as last argument, but does not count as last argument.
 
 
 ### LICENSE

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ the sequtils `a` is `_`, `a` is `it`
 var n = zip(a, b) --> map(it[0] + it[1]).fold(0, a + it)
 ```
 
-## reduce
+### reduce
 
 Same as fold, but with the iterator converted to a tuple where
 `it[0]` is the current result and `it[1]` the actual iterator on the list.

--- a/test.nim
+++ b/test.nim
@@ -8,6 +8,13 @@ let aArray = [2, 8, -4]
 let bArray = [0, 1, 2]
 let cArray = ["zero", "one", "two"]
 
+type 
+  Suit {.pure.} = enum
+    diamonds = (0, "D"),
+    hearts = (1, "H"), 
+    spades = (2, "S"), 
+    clubs = (3, "C")
+     
 proc f(a: int, b: int): int =
   a + b
 
@@ -105,6 +112,9 @@ suite "valid chains":
   test "array filter":
     check((aArray --> filter(it > 2)) == [0, 8, 0])
 
+  test "array filterSeq":
+    check((aArray --> filterSeq(it > 2)) == @[8])
+
   test "array exists":
     check((aArray --> exists(it > 0)))
 
@@ -183,3 +193,9 @@ suite "valid chains":
   test "seq indexedMapSeq":
     check((a --> indexedMapSeq(it).map(it[0] + it[1])) == @[2, 9, -2])
 
+  test "enum mapSeq":
+    check((Suit --> mapSeq($it)) == @["D", "H", "S", "C"])
+
+  test "enum find":
+    check ((Suit --> find($it == "H")) == some(Suit.hearts))
+    check ((Suit --> find($it == "X")) == none(Suit))

--- a/test.nim
+++ b/test.nim
@@ -1,31 +1,50 @@
-import unittest, zero_functional, options
+import unittest, zero_functional, options, lists, macros, strutils
 
+# different lists
 let a = @[2, 8, -4]
 let b = @[0, 1, 2]
 let c = @["zero", "one", "two"]
 
+# different arrays
 let aArray = [2, 8, -4]
 let bArray = [0, 1, 2]
 let cArray = ["zero", "one", "two"]
 
+
 type 
+  # Check working with enum type
   Suit {.pure.} = enum
     diamonds = (0, "D"),
     hearts = (1, "H"), 
     spades = (2, "S"), 
     clubs = (3, "C")
 
-type Pack = ref object
-  rows: seq[int]
+  ## User-defined that supports Iterator and random access. 
+  Pack = ref object
+    rows: seq[int]
+  
+  ## same as Pack but without the `add` function
+  PackWoAdd = ref object
+    rows: seq[int]
+  
 proc len(pack: Pack) : int = 
   pack.rows.len()
 proc `[]`(pack: Pack, idx: int) : int  = 
   pack.rows[idx]
 proc add(pack: Pack, t: int)  = 
   pack.rows.add(t)
-proc initInternal*(pack: Pack) : Pack = 
-  Pack(rows: @[])
+
+proc len(pack: PackWoAdd) : int = 
+  pack.rows.len()
+proc `[]`(pack: PackWoAdd, idx: int) : int  = 
+  pack.rows[idx]
   
+## init_zf is used to create the user-defined Pack item
+proc init_zf(a: Pack): Pack =
+  Pack(rows: @[])
+proc init_zf(a: PackWoAdd): PackWoAdd =
+  PackWoAdd(rows: @[])
+
 proc f(a: int, b: int): int =
   a + b
 
@@ -35,9 +54,38 @@ proc g(it: int): int =
   else:
     result = it + 1
 
+## Macro that checks that the expression compiles
+## Calls "check"
+macro accept*(e: untyped): untyped =
+  static: 
+    assert(compiles(e))
+  result = quote:
+    check(`e`)
+
+## Checks that the given expression is rejected by the compiler.
+template reject*(e) =
+  static: assert(not compiles(e))
+
+## This is kind of "TODO" - when an expression does not compile due to a bug
+## and it actually should compile, the expression may be surrounded with 
+## `check_if_compile'. This macro will complain to use `check` when the expression
+## actually gets compilable. 
+macro check_if_compiles*(e: untyped): untyped =
+  let content = repr(e)
+  let msg = "[WARN]: Expression compiles. Use 'check' around '" & `content` & "'"
+
+  result = quote:
+    when compiles(check(`e`)):
+      stderr.writeLine(`msg`)
+      check(`e`)
+    else:
+      discard
+
+
 suite "valid chains":
+
   test "basic filter":
-    check((a --> filter(it > 0)) == @[2, 8])
+    check(a --> filter(it > 0) == @[2, 8])
 
   test "basic zip":
     check((zip(a, b, c) --> filter(it[0] > 0 and it[2] == "one")) == @[(8, 1, "one")])
@@ -68,25 +116,25 @@ suite "valid chains":
     check((a --> fold(0, a + it)) == 6)
 
   test "map with filter":
-    check((a --> map(it + 2).filter(it mod 4 == 0)) == @[4])
+    check((a --> map(it + 2) --> filter(it mod 4 == 0)) == @[4])
 
   test "map with exists":
-    check((a --> map(it + 2).exists(it mod 4 == 0)))
+    check((a --> map(it + 2) --> exists(it mod 4 == 0)))
 
   test "map with all":
-    check(not (a --> map(it + 2).all(it mod 4 == 0)))
+    check(not (a --> map(it + 2) --> all(it mod 4 == 0)))
 
   test "map with fold":
-    check((a --> map(g(it)).fold(0, a + it)) == 10)
+    check((a --> map(g(it)) --> fold(0, a + it)) == 10)
 
   test "map with changed type":
     check((a --> mapSeq($it)) == @["2", "8", "-4"])
   
   test "filter with exists":
-    check(not (a --> filter(it > 2).exists(it == 4)))
+    check(not (a --> filter(it > 2) --> exists(it == 4)))
 
   test "filter with index":
-    check((a --> filter(it mod 2 == 0).index(it < 0)) == 2)
+    check((a --> filter(it mod 2 == 0) --> index(it < 0)) == 2)
 
   test "foreach":
     var sum = 0
@@ -144,7 +192,7 @@ suite "valid chains":
 
   test "array indexedMap":
     check((aArray --> indexedMap(it)) == @[(0, 2), (1, 8), (2, -4)])
-    check((aArray --> map(it + 2).indexedMap(it).map(it[0] + it[1])) == @[4, 11, 0])
+    check((aArray --> map(it + 2) --> indexedMap(it) --> map(it[0] + it[1])) == @[4, 11, 0])
   
   test "array fold":
     check((aArray --> fold(0, a + it)) == 6)
@@ -165,7 +213,7 @@ suite "valid chains":
     check(not (aArray --> filter(it > 2) --> exists(it == 4)))
 
   test "array filter with index":
-    check((aArray --> filter(it mod 2 == 0).index(it < 0)) == 2)
+    check((aArray --> filter(it mod 2 == 0) --> index(it < 0)) == 2)
 
   test "array foreach":
     var sum = 0
@@ -174,7 +222,7 @@ suite "valid chains":
 
   test "array foreach with index":
     var sum_until_it_gt_2 = 0
-    check((aArray --> foreach(sum_until_it_gt_2 += it).index(it > 2)) == 1)
+    check((aArray --> foreach(sum_until_it_gt_2 += it) --> index(it > 2)) == 1)
     check(sum_until_it_gt_2 == 10) # loop breaks when condition in index is true
   
   test "array with foreach change in-place":
@@ -191,10 +239,11 @@ suite "valid chains":
     check(not n)
 
   test "array filterSeq":
-    check((aArray --> map(it * 2).filterSeq(it > 0)) == @[4, 16])
+    check((aArray --> map(it * 2) --> filterSeq(it > 0)) == @[4, 16])
+    check((aArray --> map(it * 2) --> filter(it > 0)) == [4, 16, 0])
 
   test "array mapSeq":
-    check((aArray --> map(it + 2).mapSeq(it * 2)) == @[8, 20, -4])
+    check((aArray --> map(it + 2) --> mapSeq(it * 2)) == @[8, 20, -4])
 
   test "array sub":
     check((aArray--> sub(1)) == [0, 8, -4])
@@ -206,14 +255,18 @@ suite "valid chains":
     check((aArray --> subSeq(1,2)) == @[8])
     check((aArray --> subSeq(1,^1)) == @[8])
     
+  test "array indexedMap":
+    check((aArray --> map(it + 2) --> indexedMap(it) --> map(it[0] + it[1])) == @[4, 11, 0])
+
   test "seq filterSeq":
     check((a --> filterSeq(it > 0)) == @[2, 8])
+    check((a --> filter(it > 0)) == @[2, 8])
 
   test "seq mapSeq":
     check((a --> mapSeq(it * 2)) == @[4, 16 , -8])
 
   test "seq indexedMap":
-    check((a --> indexedMap(it).map(it[0] + it[1])) == @[2, 9, -2])
+    check((a --> indexedMap(it) --> map(it[0] + it[1])) == @[2, 9, -2])
 
   test "seq sub":
     check((a --> filter(idx >= 1)) == @[8, -4])
@@ -221,11 +274,12 @@ suite "valid chains":
     check((a --> sub(1,2)) == @[8])
     check((a --> sub(1,^1)) == @[8])
 
-  test "enum mapSeq":
-    check((Suit --> mapSeq($it)) == @["D", "H", "S", "C"])
+  test "enum map":
+    check((Suit --> map($it)) == @["D", "H", "S", "C"])
 
-  test "enum filterSeq":
-    check((Suit --> filterSeq($it == "H")) == @[Suit.hearts])
+
+  test "enum filter":
+    check((Suit --> filter($it == "H")) == @[Suit.hearts])
 
   test "enum find":
     check ((Suit --> find($it == "H")) == some(Suit.hearts))
@@ -233,8 +287,9 @@ suite "valid chains":
 
   test "multi ascending":
     template ascending(s: untyped) : bool = # check if the elements in seq or array are in ascending order
-      s --> sub(1).all(s[idx]-s[idx-1] > 0)
-      #s --> all(idx == 0 or s[idx]-s[idx-1] > 0)
+      s --> sub(1) --> all(s[idx]-s[idx-1] > 0)
+      # alternative implementation: 
+      # s --> all(idx == 0 or s[idx]-s[idx-1] > 0)
     check(ascending(a) == false)
     check(ascending(b) == true)
     check(ascending(aArray) == false)
@@ -252,23 +307,112 @@ suite "valid chains":
     let p = Pack(rows: @[0,1,2,3])
     check((p --> filterSeq(it != 0)) == @[1,2,3]) 
     check((p --> filter(it != 0)).rows ==  @[1,2,3])
-
   test "empty":
     let e : seq[int] = @[]
     let res : seq[int] = @[]
     check((e --> all(false)) == true)
     check((e --> exists(false)) == false)
     check((e --> map(it * 2)) == res)
-    check((e --> filter(it > 0).map(it * 2)) == res)
+    check((e --> filter(it > 0) --> map(it * 2)) == res)
 
   test "flatten":
     let f = @[@[1,2,3],@[4,5],@[6]]
     check((f --> flatten()) == @[1,2,3,4,5,6])
 
   test "flatten sum":
-    check((@[a,b] --> flatten().fold(0, a + it)) == 9)
+    check((@[a,b] --> flatten() --> fold(0, a + it)) == 9)
 
   test "zip flatten":
-    # TODO iterate tuple?!
-    #echo((zip(a,b) --> flatten()))
     check((zip(a,b) --> flatten()) == @[2,0,8,1,-4,2])
+
+  test "change DoublyLinkedList in-place":
+    var d = initDoublyLinkedList[int]()
+    d.append(1)
+    d.append(2)
+    d.append(3)
+    d --> foreach(it = it * 2) # change d in-place
+    check((d --> filterSeq(it > 2)) == @[4, 6]) 
+    check((d --> mapSeq(float(it) * 1.5)) == @[3.0, 6.0, 9.0])
+  
+  test "create DoublyLinkedList":
+    var d = initDoublyLinkedList[int]()
+    d.append(1)
+    d.append(2)
+    d.append(3)
+    let e : DoublyLinkedList[string] = (d --> map(float(it) * 2.4) --> filter(it < 6.0) --> map($it))
+    check((e --> map(it) --> to(seq[string])) == @["2.4", "4.8"])
+    check((e --> map($it) --> to(seq)) == @["2.4", "4.8"])
+    check((e --> map(it) --> to(seq)) == @["2.4", "4.8"])
+
+  test "combinations":
+    ## get indices of items where the difference of the elements is 1
+    let items = @[1,5,2,9,8,3,11]
+    # ----------- 0 1 2 3 4 5 6
+    proc abs1(a: int, b: int) : bool = abs(a-b) == 1 
+    let b = items -->
+      combinations().
+      filter(abs1(c.it[0], c.it[1])).
+      map(c.idx) 
+    check(b == @[[0, 2], [2, 5], [3, 4]])
+    check(b --> all(abs1(items[it[0]], items[it[1]])))
+
+    # the same again, but store it to a new list
+    let c = items --> 
+      combinations().
+      filter(abs1(c.it[0], c.it[1])).
+      map(c.idx).
+      to(list)
+    
+    # check that all items in the list and the seq are the same
+    check(c --> all(it == b[idx]))
+
+  test "rejected flatten":
+    # some things are not possible or won't compile
+    let fArray = [[1,2,3], [4,5,6]]
+    let fList = fArray --> map(it) --> to(list)
+    let fListFlattened = fList --> flatten() --> to(list)
+    let fSeq = @[1,2,3,4,5,6]
+    
+    # flatten defaults to seq output if not explicitly set to the output format (except DoublyLinkedList)
+    reject((fArray --> flatten()) == [1,2,3,4,5,6])
+    accept((fArray --> flatten()) == fSeq)
+    # array dimensions must be explicitly given
+    reject((fArray --> flatten() --> to(array)) == [1,2,3,4,5,6]) 
+    accept((fArray --> flatten() --> to(array[6,int])) == [1,2,3,4,5,6])
+    accept((fArray --> flatten() --> to(array[8,int])) == [1,2,3,4,5,6,0,0]) # if array is too big, the array is filled with default zero
+
+    reject((fList --> flatten()) == fSeq)
+    # list is flattened to list by default
+    # comparison of DoublyLinkedList does not seem to work directly...
+    accept($(fList --> flatten()) == $fListFlattened)
+
+  test "rejected missing add function":
+    let p2 = PackWoAdd(rows: @[0,1,2,3])
+    # PackWoAdd as iterable does not define the add method (or append) - hence this won't compile
+    reject((p2 --> filter(it != 0)).rows ==  @[1,2,3]) 
+    # forced to seq -> compiles
+    accept((p2 --> filter(it != 0) --> to(seq)) == @[1,2,3])
+    # also when using map which will lead to seq output
+    accept((p2 --> filter(it != 0) --> map($it)) == @["1","2","3"])
+    accept((p2 --> filter(it != 0) --> map(it)) == @[1,2,3])
+
+  test "rejected wrong result type":
+    # a contains int and cannot be mapped to seq[string] without $ operator
+    reject((a --> filter(it > 2) --> to(seq[string])) == @["8"])
+
+  test "rejected 'to' with an integral result type":
+    reject(a --> exists(it < 0) --> to(list))
+    accept(a --> map(it) --> to(seq) == a)
+
+  test "SinglyLinkedList reversing elements":
+    var l = a --> map(it) --> to(SinglyLinkedList)
+    check(l --> map(it).to(seq) == @[-4,8,2])
+
+  test "map with operator access":
+    proc gg(): seq[string] =
+      @["1","2","3"]
+    
+    check(gg() --> map(parseInt(it))[0] == 1)
+    check(gg() --> map(parseInt(it)) --> map(1.5 * float(it))[2] == 4.5)
+    check(a --> index(it == -4) + 1 == 3)
+  

--- a/test.nim
+++ b/test.nim
@@ -164,3 +164,22 @@ suite "valid chains":
       map(it * 2).
       all(it > 4)
     check(not n)
+
+  test "array filterSeq":
+    check((aArray --> map(it * 2).filterSeq(it > 0)) == @[4, 16])
+
+  test "array mapSeq":
+    check((aArray --> map(it + 2).mapSeq(it * 2)) == @[8, 20, -4])
+
+  test "array indexedMapSeq":
+    check((aArray --> map(it + 2).indexedMapSeq(it).map(it[0] + it[1])) == @[4, 11, 0])
+
+  test "seq filterSeq":
+    check((a --> filterSeq(it > 0)) == @[2, 8])
+
+  test "seq mapSeq":
+    check((a --> mapSeq(it * 2)) == @[4, 16 , -8])
+
+  test "seq indexedMapSeq":
+    check((a --> indexedMapSeq(it).map(it[0] + it[1])) == @[2, 9, -2])
+

--- a/test.nim
+++ b/test.nim
@@ -216,4 +216,28 @@ suite "valid chains":
     check ((Suit --> find($it == "H")) == some(Suit.hearts))
     check ((Suit --> find($it == "X")) == none(Suit))
 
-    
+  test "multi ascending":
+    template ascending(s: untyped) : bool = # check if the elements in seq or array are in ascending order
+      s --> sub(1).all(s[idx]-s[idx-1] > 0)
+      #s --> all(idx == 0 or s[idx]-s[idx-1] > 0)
+    check(ascending(a) == false)
+    check(ascending(b) == true)
+    check(ascending(aArray) == false)
+    check(ascending(bArray) == true)
+
+  test "filter template":
+    let stuttered = @[0,1,1,2,2,2,3,3]
+    let stutteredArr = [0,0,1,2,3,3]
+    template destutter(s: untyped) : untyped =
+      s --> filterSeq(idx == 0 or s[idx] != s[idx-1])
+    check(destutter(stuttered) == @[0,1,2,3])
+    check(destutter(stutteredArr) == @[0,1,2,3])
+
+  test "empty":
+    let e : seq[int] = @[]
+    let res : seq[int] = @[]
+    check((e --> all(false)) == true)
+    check((e --> exists(false)) == false)
+    check((e --> map(it * 2)) == res)
+    check((e --> filter(it > 0).map(it * 2)) == res)
+

--- a/test.nim
+++ b/test.nim
@@ -184,6 +184,16 @@ suite "valid chains":
   test "array indexedMapSeq":
     check((aArray --> map(it + 2).indexedMapSeq(it).map(it[0] + it[1])) == @[4, 11, 0])
 
+  test "array sub":
+    check((aArray--> sub(1)) == [0, 8, -4])
+    check((aArray --> sub(1,2)) == [0, 8, 0])
+    check((aArray --> sub(1,^1)) == [0, 8, 0])
+
+  test "array subSeq":
+    check((aArray --> subSeq(1)) == @[8, -4])
+    check((aArray --> subSeq(1,2)) == @[8])
+    check((aArray --> subSeq(1,^1)) == @[8])
+    
   test "seq filterSeq":
     check((a --> filterSeq(it > 0)) == @[2, 8])
 
@@ -193,9 +203,17 @@ suite "valid chains":
   test "seq indexedMapSeq":
     check((a --> indexedMapSeq(it).map(it[0] + it[1])) == @[2, 9, -2])
 
+  test "seq sub":
+    check((a --> filter(idx >= 1)) == @[8, -4])
+    check((a --> sub(1)) == @[8, -4])
+    check((a --> sub(1,2)) == @[8])
+    check((a --> sub(1,^1)) == @[8])
+
   test "enum mapSeq":
     check((Suit --> mapSeq($it)) == @["D", "H", "S", "C"])
 
   test "enum find":
     check ((Suit --> find($it == "H")) == some(Suit.hearts))
     check ((Suit --> find($it == "X")) == none(Suit))
+
+    

--- a/zero_functional.nim
+++ b/zero_functional.nim
@@ -7,6 +7,7 @@ const indexVariableName = "idx"
 const internalIteratorName = "__" & iteratorVariableName & "__"
 const useInternalAccu = accuVariableName != "result"
 const internalAccuName = if (useInternalAccu): "__" & accuVariableName & "__" else: "result"
+const emptyIdentifier = "__empty__"
 
 type 
   ExtNimNode = ref object ## Store additional info the current NimNode used in the inline... functions
@@ -240,8 +241,13 @@ proc inlineMap(ext: ExtNimNode, indexed: bool = false, toSeq: bool = false): Ext
         else:
           `resultIdent`.add(`next`)
     else:
+      let emptyIdent = newIdentNode(emptyIdentifier)
       ext.node = quote:
-        `resultIdent`.add(`next`)
+        if `emptyIdent`:
+          `emptyIdent` = false
+          `resultIdent` = @[`next`]
+        else:
+          `resultIdent`.add(`next`)
   else:
     ext.node = quote:
       let `itIdent` = `next`
@@ -262,8 +268,13 @@ proc inlineFilter(ext: ExtNimNode, toSeq: bool = false): ExtNimNode {.compileTim
         else:
           `resultIdent`.add(`itPrevIdent`)
     else:
+      let emptyIdent = newIdentNode(emptyIdentifier)
       push = quote:
-        `resultIdent`.add(`itPrevIdent`)
+        if `emptyIdent`:
+          `emptyIdent` = false
+          `resultIdent` = @[`itPrevIdent`]
+        else:
+          `resultIdent`.add(`itPrevIdent`)
     ext.node = quote:
       if `adaptedTest`:
         `push`
@@ -286,15 +297,13 @@ proc inlineExists(ext: ExtNimNode): ExtNimNode {.compileTime.} =
 
 proc inlineFind(ext: ExtNimNode): ExtNimNode {.compileTime.} = 
   let adaptedTest = ext.adapt()
-  let listRef = ext.listRef
-  let index = newIdentNode(indexVariableName) 
-  
+  let resultIdent = ext.res
+  let itIdent = ext.prevItNode()
   ext.node = quote:
     if `adaptedTest`:
-      return some(`listRef`[`index`])
-  let f = quote:
-    return none(`listRef`[0].type)
-  ext.finals.add(f)
+      return some(`itIdent`)
+    else:
+      `resultIdent` = none(`itIdent`.type) # TODO: this should be optimized
   result = ext
 
 proc inlineAll(ext: ExtNimNode): ExtNimNode {.compileTime.} =
@@ -315,6 +324,7 @@ proc inlineForeach(ext: ExtNimNode): ExtNimNode {.compileTime.} =
     let listRef = ext.listRef
     let index = newIdentNode(indexVariableName) 
     ext.node = quote:
+      # changing the iterator content will only work with indexable + variable containers
       `listRef`[`index`] = nil
     for idx,child in ext.node:
       if child.kind == nnkNilLit:
@@ -366,7 +376,8 @@ proc inlineSeq(ext: ExtNimNode): ExtNimNode {.compileTime.} =
   let node = ext.node
   let idxIdent = newIdentNode(indexVariableName)
   ext.node = quote:
-    for `idxIdent`, `itIdent` in `node`:
+    var `idxIdent` = 0
+    for `itIdent` in `node`:
       nil
   ext.nextIndexInc = true
   result = ext
@@ -435,21 +446,31 @@ proc iterHandler(args: NimNode): NimNode {.compileTime.} =
   var code = result[^1]
   let initials = nnkStmtList.newTree()
   result[^1].add(initials)
+  var forceSeq = false
 
   if args.len > 0 and args[^1].len > 0:
     let lastCall = $args[^1][0]
     if lastCall in SEQUENCE_HANDLERS:
+      forceSeq = lastCall.endsWith("Seq")
       let resultIdent = newIdentNode("result")
-      let resultType = compileTimeTypeInfer(args)
-      let zero = quote:
-        `resultIdent` = `resultType`
+      let zero = 
+        if not forceSeq:
+          let resultType = compileTimeTypeInfer(args)
+          quote:
+            `resultIdent` = `resultType`
+        else:
+          let emptyIdent = newIdentNode(emptyIdentifier)
+          quote:
+            var `emptyIdent` = true
+
       result[^1].add(zero)
   var index = 0
   let listRef = args[0]
   let finals = nnkStmtList.newTree()
+  
   for arg in args:
     let last = arg == args[^1]
-    let ext = arg.newExtNode(index, last, initials, finals, listRef).inlineElement()
+    let ext = arg.newExtNode(index, last, initials, finals, listRef, forceSeq).inlineElement()
     let newCode = ext.node.getStmtList()
     code.add(ext.node)
     if newCode != nil:
@@ -458,7 +479,25 @@ proc iterHandler(args: NimNode): NimNode {.compileTime.} =
       index += 1
   if finals.len > 0:
     result[^1].add(finals)
-  
+
+  proc findForNode(node: NimNode) : NimNode = 
+    if node.kind == nnkForStmt:
+      return node
+    for child in node:
+      let res = child.findForNode()
+      if res != nil:
+        return res
+    return nil
+
+  if args[0].len == 0 or (args[0][0].kind == nnkIdent and $args[0][0] != "zip"):
+    let forNode = result.findForNode()
+    if forNode != nil:
+      # add index increment to end of the for loop
+      let idxIdent = newIdentNode(indexVariableName)
+      let incrIdx = quote:
+        `idxIdent` += 1
+      forNode[^1].add(incrIdx)
+
   result = nnkCall.newTree(result)
 
 macro connect*(args: varargs[untyped]): untyped =

--- a/zero_functional.nim
+++ b/zero_functional.nim
@@ -1,26 +1,42 @@
-import strutils, sequtils, macros, options, sets, lists, typetraits
+import sequtils, macros, options, sets, lists, typetraits, strutils
 
 const iteratorVariableName = "it"
 const accuVariableName = "a"
+const combinationsId = "c"
 const indexVariableName = "idx"
 
 const internalIteratorName = "__" & iteratorVariableName & "__"
 const useInternalAccu = accuVariableName != "result"
 const internalAccuName = if (useInternalAccu): "__" & accuVariableName & "__" else: "result"
-const emptyIdentifier = "__empty__"
+const implicitTypeSuffix = "?" # used when result type is automatically determined
+const listIteratorName = "__itlist__"
+const listIteratorInnerName = "__itlist2__"
 
 type 
+
+  Command {.pure.} = enum
+    ## All available commands.
+    ## 'to' - is a virtual command
+    all, combinations, exists, filter, find, flatten, fold, foreach, index, indexedMap, map, reduce, sub, zip
+
   ExtNimNode = ref object ## Store additional info the current NimNode used in the inline... functions
     node: NimNode     ## the current working node / the current function
     index: int        ## index used for the created iterator - 0 for the first 
     isLastItem: bool  ## true if the current item is the last item in the command chain
     initials: NimNode ## code section before the first iterator where variables can be defined
+    endloop: NimNode  ## code at the end of the for / while loop
     finals: NimNode   ## code to set the final operations, e.g. the result
     listRef:  NimNode ## reference to the list the iterator is working on
+    typedescription: string ## type description of the outer list type
+    resultType: string ## result type when explicitly set
     nextIndexInc: bool ## if set to true the index will be increment by 1 for the next iterator 
-  
-type
 
+  ## used for "combinations" command as output
+  Combination*[A,T] = object
+    it: array[A,T]
+    idx: array[A,int]
+
+type
   FiniteIndexable[T] = concept a
     a.low() is int
     a.high() is int
@@ -30,13 +46,70 @@ type
     a.len() is int
     a[int]
 
+  FiniteIndexableLenIter[T] = concept a
+    a.len() is int
+    a[int] is T 
+    for it in a:
+      type(it) is T
+
+  Iterable[T] = concept a
+    for it in a:
+      type(it) is T
+  
+  Appendable[T] = concept a, var b
+    for it in a:
+      type(it) is T
+    b.append(T)
+
+  Addable[T] = concept a, var b
+    for it in a:
+      type(it) is T
+    b.add(T)
+  
 
 static: # need to use var to be able to concat
-  let FORCE_SEQ_HANDLERS = ["indexedMap", "filterSeq", "mapSeq", "subSeq", "flatten", "zip"].toSet
-  var SEQUENCE_HANDLERS = ["map", "filter", "sub", "subSeq"].toSet
-  var HANDLERS = ["exists", "any", "all", "index", "fold", "foreach", "find", "del"].toSet
+  let PARAMETERLESS_CALLS = [$Command.flatten, $Command.combinations].toSet
+  let FORCE_SEQ_HANDLERS = [$Command.indexedMap, $Command.flatten, $Command.zip].toSet
+  var SEQUENCE_HANDLERS = [$Command.map, $Command.filter, $Command.sub, $Command.combinations].toSet
+  var HANDLERS = [$Command.exists, $Command.all, $Command.index, $Command.fold, $Command.reduce, $Command.foreach, $Command.find].toSet
   SEQUENCE_HANDLERS.incl(FORCE_SEQ_HANDLERS)
   HANDLERS.incl(SEQUENCE_HANDLERS)
+
+## Converts the id-string to the given command.
+proc toCommand(key: string): Option[Command] =
+  for it in Command:
+    if $it == key:
+      return some(it)
+  return none(Command)
+
+proc zf_fail(msg: string) {.compileTime.} =
+  assert(false, ": " & msg)
+
+## Special implementation to initialize array output.
+proc init_zf*[A, T, U](s: array[A,T], handler: proc(it: T): U): array[A, U] =
+  discard
+  
+## Special implementation to initialize DoublyLinkedList output.
+proc init_zf*[T, U](a: DoublyLinkedList[T], handler: proc(it: T): U): DoublyLinkedList[U] =
+  initDoublyLinkedList[U]()
+## Special implementation to initialize SinglyLinkedList output.
+proc init_zf*[T, U](a: SinglyLinkedList[T], handler: proc(it: T): U): SinglyLinkedList[U] =
+  initSinglyLinkedList[U]()
+
+## This one could be overwritten when the own type is a template and could be mapped to different
+## target type.
+## Default is seq output type.
+proc init_zf*[T, U](a: Iterable[T], handler: proc(it: T): U): seq[U] =
+  @[]
+    
+## General init_zf for iterable types.
+## This should be overwritten for user defined types because otherwise the default = seq[T] on will be created.
+proc init_zf*[T](a: Iterable[T]): Iterable[T] =
+  proc ident(it: T): T = it
+  init_zf(a, ident)
+
+proc createCombination*[A,T](it: array[A,T], idx: array[A,int]): Combination[A,T] =
+  result = Combination[A,T](it: it, idx: idx)
 
 ## iterator over tuples (needed for flatten to work on tuples, e.g. from zipped lists)
 iterator items*[T: tuple](a:T) : untyped = 
@@ -53,44 +126,259 @@ iterator items*[T: FiniteIndexableLen](f:T) : untyped =
   for i in 0..<f.len():
     yield f[i]
 
-proc compileTimeTypeInfer(node: NimNode): NimNode =
-  let x = node[0]
-  result = quote:
-    `x`.type
+## Add item to array
+proc addItemZf*[A,T](a: var array[A,T], idx: int, item: T) = 
+  a[idx] = item
+
+## Add item to seq. Actually the below Addable could be used, but this does not always work out.
+proc addItemZf*[T](a: var seq[T], idx: int, item: T) =
+  discard(idx)
+  a.add(item)
+  
+## Add item to type where an "add" proc is defined for
+proc addItemZf*[T](a: var Addable[T], idx: int, item: T) =
+  discard(idx)
+  a.add(item)
+
+## Add item to type where an "append" proc is defined for (e.g. DoublyLinkedList)
+proc addItemZf*[T](a: var Appendable[T], idx: int, item: T) =
+  discard(idx)
+  a.append(item)
+
+## Special implementation for ``SinglyLinkedList`` which has only a ``preprend``
+proc addItemZf*[T](a: var SinglyLinkedList[T], idx: int, item: T) =
+  discard(idx)
+  a.prepend(item)
+
+## Replace the given identifier by the string expression
+proc replace(node: NimNode, searchNode: NimNode, replNode: NimNode): NimNode =
+  result = node
+  if node.len > 0: 
+    for i in 0..<node.len:
+      let child = node[i]
+      if child == searchNode:
+        node[i] = replNode
+      else:
+        node[i] = child.replace(searchNode, replNode)
+  elif node == searchNode:
+    result = replNode
+
+## Find a node given its kind and - optionally - its content.
+proc findNode(node: NimNode, kind: NimNodeKind, content: string = nil) : NimNode = 
+  if node.kind == kind and (content == nil or content == $node):
+    return node
+  for child in node:
+    let res = child.findNode(kind)
+    if res != nil:
+      return res
+  return nil
+
+## Searches for a given node type and returns the node and its path (indices) in the given root node
+proc findNodePath(node: NimNode, kind: NimNodeKind, content: string = nil) : (NimNode,seq[int]) = 
+  result = (nil, @[])
+  for i,child in node:
+    if child.kind == kind and (content == nil or content == $node):
+      return (child,@[i])
+    let res = child.findNodePath(kind, content)
+    if (res[0] != nil) and ((result[1].len == 0) or (result[1].len > res[1].len + 1)):
+      result[0] = res[0] # the found node
+      result[1] = @[i]   # index in current node
+      result[1].add(res[1]) # add the children's indices at the end
+
+## Shortcut to get the ident label of a node
+proc label(node: NimNode): string = 
+  if node.kind == nnkIdent:
+    return $node
+  return ""
+
+## Creates the result tuple for the zip operation.
+proc createZipTuple(node: NimNode): NimNode =
+  var ex = ""
+  for i in 1..<node.len:
+    if ex.len > 0:
+      ex &= ","
+    ex &= node[i].repr & "[0]"
+  ex = "(" & ex & ")"
+  result = parseExpr(ex)
+
+## Gets the result type, depending on the input-result type and the typedescription of the input type.
+## When the result type was given explicitly by the user that type is used.
+## Otherwise the template argument is determined by the input type.
+proc getResType(resultType: string, td: string): (NimNode, bool) {.compileTime.} = 
+    if resultType == nil:
+      return (nil, false)
+    var resType = resultType
+    let explicitType = not resultType.endswith(implicitTypeSuffix)
+    if not explicitType:
+      resType = resType[0..resType.len-1-implicitTypeSuffix.len]
+
+    let idx = resType.find("[")
+    if idx != -1:
+      result = (parseExpr(resType), explicitType)
+    else:
+      let res = newIdentNode(resType)
+      let idx2 = td.find("[")
+      var q : NimNode 
+      if idx2 != -1:
+        var tdarg = td[idx2+1..td.len-2]
+        let idxComma = tdarg.find(", ")
+        let idxBracket = tdarg.find("[")
+        if idxComma != -1 and (idxBracket == -1 or idxBracket > idxComma) and resType != "array":
+          # e.g. array[0..2,...] -> seq[...]
+          tdarg = tdarg[idxComma+2..tdarg.len-1]
+        q = parseExpr(resType & "[" & tdarg & "]")
+      else:
+        q = quote:
+          `res`[int] # this is actually a dummy type
+      result = (q, false)
+
+## Creates the function that returns the final result of all combined commands.
+## The result type depends on map, zip or flatten calls. It may be set by the user explicitly using to(...)
+proc createAutoProc(node: NimNode, isSeq: bool, resultType: string, td: string): NimNode =
+  let resultIdent = newIdentNode("result")
+  var (resType, explicitType) = getResType(resultType, td)
+
+  # set a default result in case the resType is not nil - this result will be used
+  # if there is no explicit map, zip or flatten operation called
+  if resType != nil:
+    result = quote:
+      (proc(): auto =
+          var res: `resType` 
+          `resultIdent` = init_zf(res)
+          nil)
+  # check explicitType: type was given explicitly (inclusive all template arguments) by user,
+  # then we use resType directly:
+  if explicitType:
+    discard # use default result above
+  elif isSeq:
+    # now we try to determine the result type of the operation automatically...
+    # this is a bit tricky as the operations zip, map and flatten may / will alter the result type.
+    # hence we try to apply the map-operation to the iterator, etc. to get the resulting iterator (and list) type.
+    let listRef = node[0]
+    let itIdent = newIdentNode(iteratorVariableName) # the original "it" used in the closure of "map" command
+    let idxIdent = newIdentNode(indexVariableName)
+    var handlerIdx = 0
+    var handler : NimNode = nil
+    let comboNode = newIdentNode(combinationsId)
+    # the "handler" is the default mapping ``it`` to ``it`` (if "map" is not used)
+    var handlerInit : NimNode = nil
+
+    for child in node:
+      if child.len > 0:
+        let label = child[0].repr
+        if label == $Command.map or label == $Command.indexedMap:
+          let isIndexed = label == $Command.indexedMap
+          var params = child[1].copyNimTree() # params of the map command
+          # use / overwrite the last mapping to get the final result type
+          let prevHandler = "handler" & $handlerIdx 
+          handlerIdx += 1
+          handler = newIdentNode("handler" & $handlerIdx)
+          if handlerInit == nil:
+            handlerInit = nnkStmtList.newTree()
+          else:
+            # call previous handler for each iterator instance
+            params = params.replace(itIdent, parseExpr(prevHandler & "(" & iteratorVariableName & ")"))
+          let q = quote:
+            proc `handler`(`itIdent`: auto): auto =
+              var `idxIdent` = 0  # could be used as map param
+              var `comboNode` = createCombination([0,0],[0,0]) # could be used as map param
+              when `isIndexed`:
+                `resultIdent` = (0,`params`)
+              else:
+                `resultIdent` = `params`
+              discard `idxIdent`
+              discard `comboNode`
+          handlerInit.add(q)
+
+        elif label == $Command.zip:
+          # zip(a,b,c) => params = (a[0],b[0],c[0])
+          let params = createZipTuple(child.copyNimTree())
+          handlerIdx += 1
+          handler = newIdentNode("handler" & $handlerIdx)
+          let q = quote:
+            proc `handler`(`itIdent`: auto): auto =
+              `params`
+          handlerInit = nnkStmtList.newTree().add(q)
+
+        elif label == $Command.flatten and resultType != nil:
+          # try to find the resulting type of the flatten operation
+          # e.g. list[array[2,int]] --> flatten() => list[int]
+          let actualType = resType.repr
+          var innerType = "int"
+          if actualType.endswith("]]"):
+            var idx = actualType.rfind("[")
+            innerType = actualType[idx+1..actualType.len-3]
+            idx = innerType.rfind(", ")
+            if idx != -1:
+              innerType = innerType[idx+2..innerType.len-1]
+          let idx = actualType.find('[')
+          let newType = actualType[0..idx-1] & "[" & innerType & "]" 
+          handlerInit = nil
+          handlerIdx = 0
+          resType = parseExpr(newType)
+          result = quote:
+            (proc(): auto =
+                var res: `resType`
+                `resultIdent` = init_zf(res)
+                nil)
+      
+    if handlerInit != nil:
+      # we have a handler(-chain): use it to map the result typpe
+      let q = quote:
+        (proc(): auto =
+            `handlerInit`
+            when `resultType` == nil:
+              `resultIdent` = init_zf(`listRef`,`handler`)
+            else:
+              var res: `resType`
+              `resultIdent` = init_zf(res,`handler`)
+            nil)
+      result = q
+    elif resultType == nil:
+      # result type was not given and map/zip/flatten not used: 
+      # use the same type as in the original list
+      result = quote:
+        (proc(): auto =
+            `resultIdent` = init_zf(`listRef`)
+            nil)        
+  else:
+    # no sequence output:
+    # we do _not_ need to initialize the resulting list type here
+    result = quote:
+      (proc (): auto =
+        nil)
 
 proc newExtNode(node: NimNode, 
                    index: int, 
                    isLastItem: bool,
                    initials: NimNode,
+                   endloop: NimNode,
                    finals: NimNode,
                    listRef: NimNode,
+                   typedescription: string,
+                   resultType: string,
                    nextIndexInc = false): ExtNimNode =
   result = ExtNimNode(node: node, 
                       index: index, 
                       isLastItem: isLastItem,
                       initials: initials,
+                      endloop: endloop,
                       finals: finals,
                       listRef: listRef,
+                      typedescription: typedescription,
+                      resultType: resultType,
                       nextIndexInc: nextIndexInc)
 
 proc clone(x: ExtNimNode): ExtNimNode {.compileTime.} =
     result = x.node.newExtNode(index = x.index, 
                                isLastItem = x.isLastItem, 
                                initials = x.initials,
+                               endloop = x.endloop,
                                finals = x.finals,
                                listRef = x.listRef,
+                               typedescription = x.typedescription,
+                               resultType = x.resultType,
                                nextIndexInc = x.nextIndexInc)
-
-proc iterFunction(tpe: NimNode): NimNode {.compileTime.} =
-  let empty = newEmptyNode()
-  result = nnkLambda.newTree(
-    empty,
-    empty,
-    empty,
-    nnkFormalParams.newTree(tpe),
-    empty,
-    empty,
-    nnkStmtList.newTree())
 
 proc mkItNode(index: int) : NimNode {.compileTime.} = 
   newIdentNode(internalIteratorName & ("$1" % $index))
@@ -114,16 +402,22 @@ proc adapt(ext: ExtNimNode, index=1, inFold=false): NimNode {.compileTime.} =
       return newIdentNode(internalAccuName)
     else:
       return fun
-  of nnkFloatLit..nnkFloat128Lit, nnkCharLit..nnkUInt64Lit, nnkStrLit..nnkTripleStrLit, nnkSym:
+  of nnkFloatLit..nnkFloat128Lit, nnkCharLit..nnkUInt64Lit, nnkStrLit..nnkTripleStrLit, nnkSym, nnkDotExpr:
     return fun
   else:
     for z in 0..<fun.len:
       let son = ext.clone()
       son.node = fun
       fun.add(son.adapt(index=z, inFold=inFold))
+      
     fun.del(0, fun.len div 2)
     return fun
 
+proc isListType(ext: ExtNimNode): bool = 
+  ext.typedescription.startswith("DoublyLinkedList") or ext.typedescription.startswith("SinglyLinkedList")
+
+## Helper that gets nnkStmtList and removes a 'nil' inside it - if present.
+## The nil is used as placeholder for further added code.
 proc getStmtList(node: NimNode, removeNil = true): NimNode =
   var child = node
   while child.len > 0:
@@ -131,54 +425,54 @@ proc getStmtList(node: NimNode, removeNil = true): NimNode =
     if child.kind == nnkStmtList:
       if removeNil:
         if child.len > 0 and child[^1].kind == nnkNilLit:
-          child.del(1,1)
+          child.del(child.len-1,1)
       return child
   return nil
     
+## Helper function that creates a list output if map, filter or flatten is the last command
+## in the chain and a list is generated as output.
+proc inlineAddElem(ext: ExtNimNode, addItem: NimNode): NimNode {.compileTime.} = 
+  let resultIdent = ext.res
+  let idxIdent = newIdentNode(indexVariableName)
+  let resultType = ext.resultType
+  let typedescr = ext.typedescription
+  quote:
+    when compiles(addItemZf(`resultIdent`, `idxIdent`, `addItem`)):
+      addItemZf(`resultIdent`, `idxIdent`, `addItem`)
+    else:
+      static:
+        when (`resultType` == nil or `resultType` == ""):
+          zf_fail("Need either 'add' or 'append' implemented in '" & `typedescr` & "' to add elements")
+        else:
+          zf_fail("Result type '" & `resultType` & "' and added item of type '" & $`addItem`.type & "' do not match!")
+
+## Implementation of the 'zip' command.
+## A list of tuples or tuple-iterators are created.
 proc inlineZip(ext: ExtNimNode): ExtNimNode {.compileTime.} =
   let itIdent = ext.itNode()
   let idxIdent = newIdentNode(indexVariableName)
+  let idxIdentZip = newIdentNode("idxZip")
   let m = nnkCall.newTree(newIdentNode("min"), nnkBracket.newTree())
   let p = nnkPar.newTree()
   var z = 0
   for arg in ext.node:
     if z > 0:
       m[^1].add(nnkCall.newTree(newIdentNode("high"), arg))
-      p.add(nnkBracketExpr.newTree(arg, idxIdent))
+      p.add(nnkBracketExpr.newTree(arg, idxIdentZip))
     z += 1
   ext.node = quote:
     let minHigh = `m`
-    for `idxIdent` in 0..minHigh:
+    var `idxIdent` = -1
+    for `idxIdentZip` in 0..minHigh:
+      `idxIdent` += 1
       let `itIdent` = `p`
+      nil
   ext.nextIndexInc = true
   result = ext
-
-proc inlineAddElem(ext: ExtNimNode, addItem: NimNode, toSeq: bool = false): NimNode {.compileTime.} = 
-  let resultIdent = ext.res
-  let idxIdent = newIdentNode(indexVariableName)
-  if not toSeq:
-    quote:
-      when compiles(`resultIdent`.add(`addItem`)):
-        `resultIdent`.add(`addItem`)
-      else:
-        when compiles(`resultIdent`.append(`addItem`)):
-          `resultIdent`.append(`addItem`)
-        else:
-          when compiles(`resultIdent`[`idxIdent`]):
-            `resultIdent`[`idxIdent`] = `addItem`
-          else:
-            static:
-              assert(false, ": Need either add, append or []= operator implemented to add elements")
-  else:
-    let emptyIdent = newIdentNode(emptyIdentifier)
-    quote:
-      if `emptyIdent`:
-        `emptyIdent` = false
-        `resultIdent` = @[`addItem`]
-      else:
-        `resultIdent`.add(`addItem`)
-
-proc inlineMap(ext: ExtNimNode, indexed: bool = false, toSeq: bool = false): ExtNimNode {.compileTime.} =
+          
+## Implementation of the 'map' command.
+## Each element of the input is mapped to a given function.
+proc inlineMap(ext: ExtNimNode, indexed: bool = false): ExtNimNode {.compileTime.} =
   let itIdent = ext.itNode()
   let adaptedF = ext.adapt()
   let idxIdent = newIdentNode(indexVariableName)
@@ -191,51 +485,52 @@ proc inlineMap(ext: ExtNimNode, indexed: bool = false, toSeq: bool = false): Ext
     next = adaptedF
 
   if ext.isLastItem:
-    ext.node = ext.inlineAddElem(next, toSeq)
+    ext.node = ext.inlineAddElem(next)
   else:
     ext.node = quote:
       let `itIdent` = `next`
   ext.nextIndexInc = true
   result = ext
 
-proc inlineFilter(ext: ExtNimNode, toSeq: bool = false): ExtNimNode {.compileTime.} =
+## Implementation of the 'filter' command.
+## The trailing commands execution depend on the filter condition to be true.
+proc inlineFilter(ext: ExtNimNode): ExtNimNode {.compileTime.} =
   let adaptedTest = ext.adapt()
   if ext.isLastItem:
-    let push = ext.inlineAddElem(ext.prevItNode(), toSeq)
+    let push = ext.inlineAddElem(ext.prevItNode())
     ext.node = quote:
       if `adaptedTest`:
         `push`
   else:
-    ext.node = quote :
+    ext.node = quote:
         if `adaptedTest`:
           nil
   result = ext
 
+## Implementation of the 'flatten' command.
+## E.g. @[@[1,2],@[3,4]] --> flatten() == @[1,2,3,4]
 proc inlineFlatten(ext: ExtNimNode): ExtNimNode {.compileTime} = 
   let itIdent = ext.itNode()
   let itPrevIdent = ext.prevItNode()
+  let idxIdent = newIdentNode(indexVariableName)
   if not ext.isLastItem:
-    let itIdent = ext.itNode()
-    let idxIdent = newIdentNode(indexVariableName)
     ext.node = quote:
-      var `idxIdent` = 0 
       for `itIdent` in `itPrevIdent`:
         `idxIdent` += 1
         nil
   else:
-    let resultIdent = ext.res
-    let emptyIdent = newIdentNode(emptyIdentifier)
+    let push = ext.inlineAddElem(itIdent)
     ext.node = quote:
       for `itIdent` in `itPrevIdent`:
-        if `emptyIdent`:
-          `emptyIdent` = false
-          `resultIdent` = @[`itIdent`]
-        else:
-          `resultIdent`.add(`itIdent`)
+        `push`
+        `idxIdent` += 1
   ext.nextIndexInc = true
   result = ext
 
-proc inlineSub(ext: ExtNimNode, toSeq: bool = false): ExtNimNode {.compileTime.} =
+## Implementation of the 'sub' command.
+## Delegates to 'filter' with the given start and end indices of the sub-list to create.
+## In sub also Backward indices (e.g. ^1) can be used.
+proc inlineSub(ext: ExtNimNode): ExtNimNode {.compileTime.} =
   # sub is re-routed as filter implementation
   let index = newIdentNode(indexVariableName)
   let minIndex = ext.node[1]
@@ -252,9 +547,11 @@ proc inlineSub(ext: ExtNimNode, toSeq: bool = false): ExtNimNode {.compileTime.}
         len(`listRef`)-`endIndexAbs` # backwards index only works with collections that have a len
     newCheck = quote:
       `index` >= `minIndex` and `index` < `endIndex`
-  ext.node = newCall("filter", newCheck)
-  return ext.inlineFilter(toSeq)
+  ext.node = newCall($Command.filter, newCheck)
+  return ext.inlineFilter()
 
+## Implementation of the 'exists' command.
+## Searches the input for a given expression. If one is found "true" is returned, else "false".
 proc inlineExists(ext: ExtNimNode): ExtNimNode {.compileTime.} =
   let adaptedTest = ext.adapt()
   let resultIdent = ext.res
@@ -266,6 +563,8 @@ proc inlineExists(ext: ExtNimNode): ExtNimNode {.compileTime.} =
       return true
   result = ext
 
+## Implementation of the 'find' command.
+## Searches the input for a given expression. Returns an option value.
 proc inlineFind(ext: ExtNimNode): ExtNimNode {.compileTime.} = 
   let adaptedTest = ext.adapt()
   let resultIdent = ext.res
@@ -278,6 +577,8 @@ proc inlineFind(ext: ExtNimNode): ExtNimNode {.compileTime.} =
       `resultIdent` = none(`itIdent`.type) 
   result = ext
 
+## Implementation of the 'all' command.
+## Returns true of the given condition is true for all elements of the input, else false.
 proc inlineAll(ext: ExtNimNode): ExtNimNode {.compileTime.} =
   let adaptedTest = ext.adapt()
   let resultIdent = ext.res
@@ -290,7 +591,7 @@ proc inlineAll(ext: ExtNimNode): ExtNimNode {.compileTime.} =
   result = ext
 
 proc findParentWithChildLabeled(node: NimNode, label: string): NimNode =
-  if node.len > 0 and node[0].kind == nnkIdent and $node[0] == label:
+  if node.len > 0 and node[0].label == label:
     return node
   for child in node:
     let parent = child.findParentWithChildLabeled(label)
@@ -298,6 +599,9 @@ proc findParentWithChildLabeled(node: NimNode, label: string): NimNode =
       return parent
   return nil
 
+## Implementation of the 'foreach' command.
+## A command may be called on each element of the input list.
+## Changing the list in-place is also supported.
 proc inlineForeach(ext: ExtNimNode): ExtNimNode {.compileTime.} =
   var adaptedExpression = ext.adapt()
   
@@ -309,7 +613,11 @@ proc inlineForeach(ext: ExtNimNode): ExtNimNode {.compileTime.} =
       let index = newIdentNode(indexVariableName)
       let rightSide = adaptedExpression[^1]
       # changing the iterator content will only work with indexable + variable containers
-      if itNode == adaptedExpression:
+      if ext.isListType():
+        let itlist = newIdentNode(listIteratorName)
+        adaptedExpression = quote:
+          `itlist`.value = `rightSide`
+      elif itNode == adaptedExpression:
         adaptedExpression = quote:
          `listRef`[`index`] = `rightSide`
       else:
@@ -325,6 +633,8 @@ proc inlineForeach(ext: ExtNimNode): ExtNimNode {.compileTime.} =
     `adaptedExpression`
   result = ext
 
+## Implementation of the 'index' command.
+## Returns the index of the element in the input list when the given expression was found or -1 if not found.
 proc inlineIndex(ext: ExtNimNode): ExtNimNode{.compileTime.} =
   let adaptedTest = ext.adapt()
   var idxIdent = newIdentNode(indexVariableName)
@@ -337,6 +647,9 @@ proc inlineIndex(ext: ExtNimNode): ExtNimNode{.compileTime.} =
       return `idxIdent` # return index
   result = ext  
 
+## Implementation of the 'fold' command.
+## Initially the result is set to initial value given by the user, then each element is added
+## to the result by subsequent calls.
 proc inlineFold(ext: ExtNimNode): ExtNimNode{.compileTime.} =
   let initialValue = ext.node[1]
   let resultIdent = ext.res
@@ -361,12 +674,84 @@ proc inlineFold(ext: ExtNimNode): ExtNimNode{.compileTime.} =
   ext.initials.add(i)
   result = ext
 
+## Implementation of the 'reduce' command.
+## Initially the result is set to the first element of the list, then each element is added
+## to the result by subsequent calls.
+proc inlineReduce(ext: ExtNimNode): ExtNimNode {.compileTime.} =
+  let prevIdent = ext.prevItNode()
+  let itIdent = ext.itNode() 
+  ext.index += 1
+  let adaptedExpression = ext.adapt()
+  let initAccu = newIdentNode("initAccu")
+  let resultIdent = ext.res()
+  let i = quote:
+    var `initAccu` = true
+  ext.initials.add(i)
+  
+  ext.node = quote:
+    if `initAccu`:
+      `resultIdent` = `prevIdent`
+      `initAccu` = false
+    else:
+      let `itIdent` = (`resultIdent`, `prevIdent`)
+      `resultIdent` = `adaptedExpression`
+  ext.nextIndexInc = true
+  result = ext
+
+## Implementation of the 'combinations' command.
+## Each two distinct elements of the input list are combined to one element.
+proc inlineCombinations(ext: ExtNimNode): ExtNimNode {.compileTime.} =
+  let idxIdent = newIdentNode(indexVariableName)
+  let idxInnerIdent = newIdentNode("idxInner")
+  let itCombo = newIdentNode(combinationsId)
+
+  if ext.isListType():
+    let itlist = newIdentNode(listIteratorName)
+    let itlistInner = newIdentNode(listIteratorInnerName)
+    let itPrevIdent = ext.prevItNode()
+    ext.node = quote:
+      var `itlistInner` = `itlist`
+      var `idxInnerIdent` = `idxIdent`
+      while `itlistInner` != nil:
+        let `itCombo` = createCombination([`itPrevIdent`, `itlistInner`.value], [`idxIdent`, `idxInnerIdent`])
+        `idxInnerIdent` += 1
+        `itlistInner` = `itlistInner`.next
+        nil
+  else:
+    let listRef = ext.listRef
+    ext.node = quote:
+      when not (`listRef` is FiniteIndexableLenIter):
+        static:
+          zf_fail("Only index with len types supported for combinations")
+      for `idxInnerIdent` in `idxIdent`+1..<`listRef`.len():
+        let `itCombo` = createCombination([`listRef`[`idxIdent`], `listRef`[`idxInnerIdent`]], [`idxIdent`, `idxInnerIdent`])
+        nil
+  result = ext
+
+## Initial creation of the outer iterator.
 proc inlineSeq(ext: ExtNimNode): ExtNimNode {.compileTime.} =
   let itIdent = ext.itNode()
   let node = ext.node
-  ext.node = quote:
-    for `itIdent` in `node`:
-      nil
+
+  if ext.isListType():
+    # list iterator implemnentation
+    let listRef = ext.listRef
+    let itlist = newIdentNode(listIteratorName)
+    ext.node = quote:
+      var `itlist` = `listRef`.head
+      while `itlist` != nil:
+        var `itIdent` = `itlist`.value
+        nil
+    let e = quote:
+      `itlist` = `itlist`.next
+    ext.endloop.add(e)
+  
+  else:
+    # usual iterator implementation
+    ext.node = quote:
+      for `itIdent` in `node`:
+        nil
+    
   ext.nextIndexInc = true
   result = ext
   
@@ -374,120 +759,144 @@ proc ensureLast(ext: ExtNimNode) {.compileTime.} =
   if not ext.isLastItem:
     error("$1 can be only last in a chain" % $ext.node[0], ext.node)
 
+proc ensureNotLast(ext: ExtNimNode) {.compileTime.} =
+  if ext.isLastItem:
+    error("$1 can not be last in a chain" % $ext.node[0], ext.node)
+
 proc ensureFirst(ext: ExtNimNode) {.compileTime.} =
   if ext.index > 0:
     error("$1 supposed to be first" % $ext.node[0], ext.node)
 
 proc ensureParameters(ext: ExtNimNode, no: int) {.compileTime.} = 
-    if ext.node.len <= no:
-      error($ext.node[0] & " needs at least $1 parameter(s)" % $no, ext.node)
+  if ext.node.len <= no:
+    error($ext.node[0] & " needs at least $1 parameter(s)" % $no, ext.node)
         
-proc inlineElement(ext: ExtNimNode, forceSeq: bool): ExtNimNode {.compileTime.} =
+## Delegates each function argument to the inline implementations of each command.
+proc inlineElement(ext: ExtNimNode): ExtNimNode {.compileTime.} =
   let label = if (ext.node.len > 0 and ext.node[0].kind == nnkIdent): $ext.node[0] else: ""
   if ext.node.kind == nnkCall and (ext.index > 0 or label in HANDLERS):
-    if label != "flatten":    
+    if not (label in PARAMETERLESS_CALLS):    
       ext.ensureParameters(1)
-    case label:
-    of "zip":
+    let cmdCheck = label.toCommand
+    if none(Command) != cmdCheck:
+      let cmd = cmdCheck.get()
+      case cmd:
+      of Command.zip:
         ext.ensureFirst()
         return ext.inlineZip()
-    of "map":
-      return ext.inlineMap(toSeq=forceSeq)
-    of "filter":
-      return ext.inlineFilter(toSeq=forceSeq)
-    of "exists":
-      ext.ensureLast()
-      return ext.inlineExists()
-    of "find":
-      ext.ensureLast()
-      return ext.inlineFind()
-    of "all":
-      ext.ensureLast()
-      return ext.inlineAll()
-    of "index":
-      ext.ensureLast()
-      return ext.inlineIndex()
-    of "indexedMap":
-      return ext.inlineMap(indexed=true, toSeq=forceSeq)
-    of "fold":
-      ext.ensureLast()
-      ext.ensureParameters(2)
-      return ext.inlineFold()
-    of "foreach":
-      return ext.inlineForeach()
-    of "any":
-      warning("any is deprecated - use exists instead")
-      return ext.inlineExists()
-    of "filterSeq":
-      return ext.inlineFilter(toSeq=true)
-    of "mapSeq":
-      return ext.inlineMap(toSeq=true)
-    of "indexedMapSeq":
-      return ext.inlineMap(indexed=true, toSeq=true)
-    of "sub":
-      return ext.inlineSub(toSeq=forceSeq)
-    of "subSeq":
-      return ext.inlineSub(toSeq=true)
-    of "flatten":
-      return ext.inlineFlatten()
+      of Command.map:
+        return ext.inlineMap()
+      of Command.filter:
+        return ext.inlineFilter()
+      of Command.exists:
+        ext.ensureLast()
+        return ext.inlineExists()
+      of Command.find:
+        ext.ensureLast()
+        return ext.inlineFind()
+      of Command.all:
+        ext.ensureLast()
+        return ext.inlineAll()
+      of Command.index:
+        ext.ensureLast()
+        return ext.inlineIndex()
+      of Command.indexedMap:
+        return ext.inlineMap(indexed=true)
+      of Command.fold:
+        ext.ensureLast()
+        ext.ensureParameters(2)
+        return ext.inlineFold()
+      of Command.reduce:
+        ext.ensureLast()
+        return ext.inlineReduce()
+      of Command.foreach:
+        return ext.inlineForeach()
+      of Command.sub:
+        return ext.inlineSub()
+      of Command.flatten:
+        return ext.inlineFlatten()
+      of Command.combinations:
+        ext.ensureNotLast()
+        return ext.inlineCombinations()
     else:
-      error("$1 is unknown" % label, ext.node)    
+      if "any" == label:
+        warning("any is deprecated - use exists instead")
+        return ext.inlineExists()
+      else:
+        error("$1 is unknown" % label, ext.node)
   else:
     ext.ensureFirst()
     return ext.inlineSeq()
 
 
-#template default[T](t: typedesc[T]): T =
-#  var v: T
-#  v
+## Check if the "to" parameter is used to generate a specific result type.
+## The requested result type is returned and the "to"-node is removed.
+proc checkTo(args: NimNode, td: string): string {.compileTime.} = 
+  let last = args[^1]
+  var resultType : string = nil
+  if last.kind == nnkCall and last[0].repr == "to":
+    args.del(args.len-1) # remove the "to" node
+    if args.len <= 1:
+      # there is no argument other than "to": add default mapping function "map(it)"
+      args.add(parseExpr($Command.map & "(" & iteratorVariableName & ")"))
+    else:
+      assert(args[^1][0].label in SEQUENCE_HANDLERS, "'to' can only be used with list results - last arg is '" & args[^1][0].label & "'")
+    resultType = last[1].repr
+    if resultType == "list": # list as a shortcut for DoublyLinkedList
+      resultType = "DoublyLinkedList"
+    elif resultType.startswith("list["):
+      resultType = "DoublyLinkedList" & resultType[4..resultType.len-1]
+  if resultType == nil:
+    for arg in args:
+      if arg.kind == nnkCall:
+        let label = arg[0].repr 
+        # shortcut handling for mapSeq(...)  <=> map(...).to(seq) and
+        #                       mapList(...) <=> map(...).to(list) - etc.
+        let isSeq = label.endswith("Seq") 
+        let isList = label.endswith("List")
+        # Check forced sequences or lists
+        if isSeq or isList or label in FORCE_SEQ_HANDLERS:
+          if isSeq:
+            arg[0] = newIdentNode(label[0..label.len-4])
+          elif isList:
+            arg[0] = newIdentNode(label[0..label.len-5])
+          if isSeq or isList or resultType == nil:
+            resultType =
+              if isSeq:
+                "seq"
+              elif isList:
+                "DoublyLinkedList"
+              elif (td.startswith("DoublyLinkedList")):
+                td & implicitTypeSuffix
+              else:
+                "seq[int]" & implicitTypeSuffix # default to sequence - and use it if isSeq is used explicitly
+  if resultType == nil and td == "enum":
+    resultType = "seq[" & $args[0] & "]" & implicitTypeSuffix
+  result = resultType
 
-proc initInternal[U](a: U): U = 
-  static:
-    assert(false, ": Need an implementation for `proc initInternal(a:" & U.name & ")`") # name is in typetraits
-
-proc initInternal*[T](a: seq[T]): seq[T] =
-  @[]
-
-proc initInternal*[A,T](a: array[A,T]): array[A,T] =
-  discard
-
-proc initInternal*[T](a: DoublyLinkedList[T]): DoublyLinkedList[T] =
-  initDoublyLinkedList[T]()
-
-proc findNode(node: NimNode, kind: NimNodeKind) : NimNode = 
-  if node.kind == kind:
-    return node
-  for child in node:
-    let res = child.findNode(kind)
-    if res != nil:
-      return res
-  return nil
-
-
-proc iterHandler(args: NimNode, debug=false): NimNode {.compileTime.} =
+## Main function that creates the outer function call.
+proc iterHandler(args: NimNode, debug: bool, td: string): NimNode {.compileTime.} =
+  let resultType = args.checkTo(td)
   let lastCall = $args[^1][0]
-  let needsFunction = (lastCall != "foreach") and (lastCall != "del")
-  let isSeq = lastCall in SEQUENCE_HANDLERS 
-  var forceSeq = lastCall in FORCE_SEQ_HANDLERS
+  let needsFunction = (lastCall != $Command.foreach) 
+  let isSeq = lastCall in SEQUENCE_HANDLERS
   var defineIdxVar = true
+  var addIdxIncr = true
 
+  # check if 'var idx' has to be created or not - and 'idx += 1' to be added
   for arg in args:
     if arg.kind == nnkCall:
       let label = $arg[0]
-      if isSeq and not forceSeq:
-        if label in FORCE_SEQ_HANDLERS:
-          forceSeq = true
-      if label == "zip" or label == "flatten":
-        # zip and flatten both use the idx already - no need to define it (prevents "unused variable idx")
+      if label == $Command.zip:
+        # zip uses the idx already - no need to define it (prevents "unused variable idx")
         defineIdxVar = false
+      elif label == $Command.flatten:
+        addIdxIncr = false
   
   var code: NimNode
   if needsFunction:
-    if isSeq and not forceSeq:
-      result = iterFunction(args.compileTimeTypeInfer())
-    else:
-      result = iterFunction(newIdentNode("auto"))
-    code = result[^1]
+    result = args.createAutoProc(isSeq, resultType, td)
+    code = result[^1].getStmtList()
     result = nnkCall.newTree(result)
   else:
     # there is no extra function, but at least we have an own section here - preventing double definitions
@@ -507,28 +916,14 @@ proc iterHandler(args: NimNode, debug=false): NimNode {.compileTime.} =
       var `idxIdent` = 0 
     init.add(identDef)
 
-  if isSeq:
-    let zero =
-      if not forceSeq:
-        let resultIdent = newIdentNode("result")
-        let x = args[0]
-        quote:
-          # for user defined types this function has to be implemented
-          `resultIdent` = initInternal(`x`)
-      else:
-        let emptyIdent = newIdentNode(emptyIdentifier)
-        quote:
-          var `emptyIdent` = true
-
-    init.add(zero)
-
   var index = 0
   let listRef = args[0]
   let finals = nnkStmtList.newTree()
-  
+  let endloop = nnkStmtList.newTree()
+
   for arg in args:
     let last = arg == args[^1]
-    let ext = arg.newExtNode(index, last, initials, finals, listRef).inlineElement(forceSeq)
+    let ext = arg.newExtNode(index, last, initials, endloop, finals, listRef, td, resultType).inlineElement()
     let newCode = ext.node.getStmtList()
     code.add(ext.node)
     if newCode != nil:
@@ -537,31 +932,63 @@ proc iterHandler(args: NimNode, debug=false): NimNode {.compileTime.} =
       index += 1
   if finals.len > 0:
     init.add(finals)
+  
+  # could be combinations of for and while, but only one while (for DoublyLinkedList) -> search while first
+  var loopNode = result.findNode(nnkWhileStmt) 
+  if loopNode == nil:
+    loopNode = result.findNode(nnkForStmt)
+  if endloop.len > 0:
+    loopNode[^1].add(endloop)
 
-  if defineIdxVar:
-    let forNode = result.findNode(nnkForStmt)
-    if forNode != nil:
-      # add index increment to end of the for loop
-      let idxIdent = newIdentNode(indexVariableName)
-      let incrIdx = quote:
-        `idxIdent` += 1
-      forNode[^1].add(incrIdx)
+  if defineIdxVar and addIdxIncr and loopNode != nil:
+    # add index increment to end of the for loop
+    let idxIdent = newIdentNode(indexVariableName)
+    let incrIdx = quote:
+      `idxIdent` += 1
+    loopNode[^1].add(incrIdx)
 
   if (debug):
     echo(repr(result))
-    # for the whole tree do:
+    # for the whole tree do (but this could crash):
     # echo(treeRepr(result))
   
+## Determines the closest possible type info of the input parameter to "-->".
+## Sometimes the getType (node) works best, sometimes getTypeInst (nodeInst).
+proc getTypeInfo(node: NimNode, nodeInst: NimNode): string =
+  var typeinfo = node
+  if typeinfo.len > 0:
+    if node.kind == nnkEnumTy:
+      result = "enum"
+    elif ($typeinfo[0] == "ref"):
+      result = $typeinfo[1]
+      let idx = result.find(":")
+      if idx != -1:
+        result = result[0..idx-1]
+    else:
+      let res = repr(nodeInst)
+      if res == nil:
+        result = repr(node)
+      else:
+        result = res
+  else:
+    let n1 = node.repr
+    let n2 = nodeInst.repr
+    if n2 == nil or n1.len > n2.len:
+      result = n1
+    else:
+      result = n2
 
-macro connect*(args: varargs[untyped]): untyped =
-  result = iterHandler(args)
+macro connectCall(td: typedesc, args: varargs[untyped]): untyped = 
+  result = iterHandler(args, false, getTypeInfo(td.getType[1], td.getTypeInst[1]))
 
+## Rearranges the node tree with the dot expressions.
 proc rearrangeDot(a: NimNode) : bool =
   result = false
   for i in 0..<a.len:
     if a[i].rearrangeDot():
       result = true
-  if a.kind == nnkDotExpr and a.len > 1 and a[0].kind == nnkCall and a[^1].kind == nnkDotExpr and a[^1][0].kind == nnkCall:
+  if a.kind == nnkDotExpr and a.len > 1 and a[0].kind == nnkCall and
+     a[^1].kind == nnkDotExpr and a[^1][0].kind == nnkCall:
     result = true
     let innerdot = a[^1]
     let innercall = innerdot[0]
@@ -571,23 +998,38 @@ proc rearrangeDot(a: NimNode) : bool =
     a[^1] = innerdot[^1]
     innerdot[^1] = innercall[0]
 
-
-proc delegateMacro(a1: NimNode, b1:NimNode, debug=false): NimNode =
-  expectKind(b1, nnkCall)
+## Preparse the call to the iterFunction.
+proc delegateMacro(a1: NimNode, b1:NimNode, debug: bool, td: string): NimNode =
   var a = a1
   var b = b1
 
-  while (a.kind == nnkInfix and a[0].kind == nnkIdent and $a[0]== "-->"):
+  # we expect b to be a call, but if we have another node - e.g. infix or bracketexpr - then
+  # we search for the actual call, do the macro expansions on the call and 
+  # add the result back into the tree later
+  var outer = b  
+  var callIndices : seq[int] = nil
+  if b.kind != nnkCall:
+    var call : NimNode
+    (call,callIndices) = outer.findNodePath(nnkCall)
+    if call != nil:
+      b = call
+    else:
+      zf_fail("Unexpected expression in macro call on right side of '-->'")
+
+  # convert multiple '-->' to one '.'-notation
+  # e.g. a --> filter(it > 0) --> map($it) gets a --> filter(it > 0).map($it) 
+  while (a.kind == nnkInfix and a[0].kind == nnkIdent and ($a[0]== "-->" or $a[0]== "-->>")):
     var new_b = nnkCall.newTree(nnkDotExpr.newTree(a[2], b[0]))
     for i in 1..<len(b):
       new_b.add(b[i])
     b = new_b
     a = a[1]
+  # sometimes the leaves need to be re-arranged
+  while b.rearrangeDot():
+    discard
 
-  while true:
-    if not b.rearrangeDot():
-      break
-
+  # now re-arrange all dot expressions to one big parameter call
+  # i.e. a --> filter(it > 0).map($it) gets a.
   let methods = b
   var m: seq[NimNode] = @[]
   var node = methods
@@ -609,11 +1051,67 @@ proc delegateMacro(a1: NimNode, b1:NimNode, debug=false): NimNode =
   for z in countdown(high(m), low(m)):
     m2.add(m[z])
   let mad = nnkArgList.newTree(m2)
-  result = iterHandler(mad, debug)
+  result = iterHandler(mad, debug, td)
 
+  if callIndices != nil: # insert the result back into the original tree
+    var c = outer
+    for idx in 0..callIndices.len-2:
+      c = c[callIndices[idx]]
+    c[callIndices[callIndices.len-1]] = result
+    result = outer
+
+## delegate call to get the type information.
+macro delegateArrow(td: typedesc, a: untyped, b: untyped): untyped =
+  result = delegateMacro(a, b, false, getTypeInfo(td.getType[1], td.getTypeInst[1]))
+
+## delegate call to get the type information (debug mode).
+macro delegateArrowDbg(td: typedesc, a: untyped, b: untyped): untyped =
+  result = delegateMacro(a, b, true, getTypeInfo(td.getType[1], td.getTypeInst[1]))
+  
+## The arrow "-->" should not be part of the left-side argument a.
+proc checkArrow(a: NimNode, b: NimNode, arrow: string): (NimNode, NimNode) = 
+  var a = a
+  var b = b
+  if a.findNode(nnkIdent, arrow) != nil:
+    if a.kind == nnkPar:
+      a = a[0]
+    if b.kind == nnkPar:
+      b = b[0]
+    var ar = a.repr
+    var br = b.repr
+    let idx = ar.find(arrow)
+    var bchange = false
+    if idx != -1:
+      br = ar[idx+3..ar.len-1] & "." & br 
+      ar = ar[0..idx-1]
+      a = parseExpr(ar)
+      bchange = true
+    if arrow in br:
+      br = br.replace(arrow, ".")
+      bchange = true
+    if bchange:
+      b = parseExpr(br)
+  result = (a,b)
+
+## Alternative call with comma separated arguments.
+macro connect*(args: varargs[untyped]): untyped =
+  result = quote:
+    connectCall(type(`args`[0]), `args`)
+  
+## general macro to invoke all available zero_functional functions
 macro `-->`*(a: untyped, b: untyped): untyped =
-  result = delegateMacro(a,b)
+  let (a,b) = checkArrow(a,b,"-->")
+  if a.kind == nnkIdent:
+    result = quote:
+      delegateArrow(type(`a`), `a`, `b`)
+  else:
+    result = delegateMacro(a, b, false, "seq")
 
 ## use this macro for debugging - will output the created code
 macro `-->>`*(a: untyped, b: untyped): untyped =
-  result = delegateMacro(a,b,true)
+  let (a,b) = checkArrow(a,b,"-->>")
+  if a.kind == nnkIdent:
+    result = quote:
+      delegateArrowDbg(type(`a`), `a`, `b`)
+  else:
+    result = delegateMacro(a, b, true, "seq")

--- a/zero_functional.nim
+++ b/zero_functional.nim
@@ -470,7 +470,7 @@ proc iterHandler(args: NimNode): NimNode {.compileTime.} =
   
   for arg in args:
     let last = arg == args[^1]
-    let ext = arg.newExtNode(index, last, initials, finals, listRef, forceSeq).inlineElement()
+    let ext = arg.newExtNode(index, last, initials, finals, listRef).inlineElement()
     let newCode = ext.node.getStmtList()
     code.add(ext.node)
     if newCode != nil:

--- a/zero_functional.nim
+++ b/zero_functional.nim
@@ -572,7 +572,3 @@ proc delegateMacro(a: NimNode, b:NimNode): NimNode =
 
 macro `-->`*(a: untyped, b: untyped): untyped =
   result = delegateMacro(a,b)
-
-when isMainModule:
-  let a = [2,8,-4]
-  echo((a--> sub(1)) == [0, 8, -4])

--- a/zero_functional.nim
+++ b/zero_functional.nim
@@ -475,7 +475,7 @@ proc inlineElement(ext: ExtNimNode): ExtNimNode {.compileTime.} =
     ext.ensureFirst()
     return ext.inlineSeq()
 
-proc iterHandler(args: NimNode): NimNode {.compileTime.} =
+proc iterHandler(args: NimNode, debug=false): NimNode {.compileTime.} =
   result = iterFunction()
   var code = result[^1]
   let initials = nnkStmtList.newTree()
@@ -540,12 +540,17 @@ proc iterHandler(args: NimNode): NimNode {.compileTime.} =
         `idxIdent` += 1
       forNode[^1].add(incrIdx)
 
+  if (debug):
+    echo(repr(result))
+    # for the whole tree do:
+    # echo(treeRepr(result))
+    
   result = nnkCall.newTree(result)
 
 macro connect*(args: varargs[untyped]): untyped =
   result = iterHandler(args)
 
-proc delegateMacro(a: NimNode, b:NimNode): NimNode =
+proc delegateMacro(a: NimNode, b:NimNode, debug=false): NimNode =
   expectKind(b, nnkCall)
   let methods = b
   var m: seq[NimNode] = @[]
@@ -568,7 +573,11 @@ proc delegateMacro(a: NimNode, b:NimNode): NimNode =
   for z in countdown(high(m), low(m)):
     m2.add(m[z])
   let mad = nnkArgList.newTree(m2)
-  result = iterHandler(mad)
+  result = iterHandler(mad, debug)
 
 macro `-->`*(a: untyped, b: untyped): untyped =
   result = delegateMacro(a,b)
+
+## use this macro for debugging - will output the created code
+macro `-->>`*(a: untyped, b: untyped): untyped =
+  result = delegateMacro(a,b,true)

--- a/zero_functional.nimble
+++ b/zero_functional.nimble
@@ -1,4 +1,4 @@
-version         = "0.0.4"
+version         = "0.0.5"
 packageName     = "zero_functional"
 author          = "Alexander Ivanov"
 description     = "a library providing zero-cost for chaining functional abstractions in Nim."


### PR DESCRIPTION
I used the old `emptyIdent` implementation to generate the sequences in case we have the `toSeq` active.
Also I removed the idx as variable from the for-loop (except when using `zip`)
I hope that doesn't complicate things too much.

On the other hand any iterable object should now work with most of the functions