### PR TITLE
Rework Zip + Reduce

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
-zero_functional
+# ignore everything ...
+**/*
+# ... except all files that have a dot of course ;-)
+!**/*.*
 nimcache
-benchmarks/test_nim
-benchmarks/test_sequtils_nim
-benchmarks/test_cpp
-benchmarks/test_crystal
-benchmarks/test.exe
-benchmarks/test_rust
-node_modules/
+**gmon.out
+# on windows: ignore all generated files
+**.exe 
+**.ilk 
+**.pdb

--- a/README.md
+++ b/README.md
@@ -182,11 +182,13 @@ check(x == @[2])
 
 `zip` can work with n sequences. `zip` is (roughly) internally translated to:
 ```nim
-# zip(a,b,c) --> ...
-let minHigh = min([b.high(), c.high()])
-a --> filter(idx <= minHigh) --> map((it, b[idx], c[idx])) --> ...
+zip(a,b,c) <=> 
+a --> zip(b,c) <~> 
+let minHigh = min([a.high(), b.high(), c.high()])
+a --> filter(idx <= minHigh) --> map(a[idx], b[idx], c[idx])
 ```
-So for zip in order to work properly at least the 2nd and following parameters have to support access with `[]` and the `high` procedure.
+On the right side of `-->` (or as 2nd and later command) the left side of `-->` is added to the zip result.
+For zip in order to work properly all arguments have to support access with `[]` and the `high` procedure.
 If those procedures are not available the macro tries to call the procedure `mkIndexable` on that parameter. Using this helper the parameter can be wrapped with a new type that supports `[]` and `high`.
 
 ### exists
@@ -264,14 +266,14 @@ Return the product of the (filtered) elements (`*`)
 #### sum
 Return the sum of the (filtered) elements (`+`).
 
-### reduceIdx
+### indexedReduce
 
-By adding the `Idx` suffix to `reduce` or to the reduce commands above, the index of the last value that was used for the `result` and the actual result of the operation are returned.
+By adding the `indexed` prefix to `reduce` or to the reduce commands above, the index of the last value that was used for the `result` and the actual result of the operation are returned.
 For `sum` and `product` this is not actually helpful but it can be used to find the indices of the `min` and `max` elements.
 
 ```nim
-check(@[11,2,0,-2,1,3,-1] --> minIdx() == (3,-2))
-check(@[11,2,0,-2,1,3,-1] --> maxIdx() == (11,0))
+check(@[11,2,0,-2,1,3,-1] --> indexedMin() == (3,-2))
+check(@[11,2,0,-2,1,3,-1] --> indexedMax() == (11,0))
 ```
 
 ### foreach

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ Similar commands like `sub` that result in parts of the lists being iterated on 
 As opposed to `filter` the condition in `drop` is ignored, once it was not true any more.
 ```nim
 check(@[-1,2,-3,4,-5] --> dropWhile(it < 0) --> sum() == -2)
-check(@[-1,2,-3,4,-5] --> filter(it < 0) --> sum() == 6)
+check(@[-1,2,-3,4,-5] --> filter(it >= 0)   --> sum() == 6)
 ```
 #### take
 `take`(`n`) works on n items of the collection and then breaking. This is useful for very large (infinite) collections or iterators - the same for `takeWhile`.

--- a/benchmarks/bench.nim
+++ b/benchmarks/bench.nim
@@ -1,7 +1,7 @@
 import times, os, strutils, sequtils, macros
 
 template finish(benchmarkName: string, a: NimNode): untyped =
-  let elapsed = epochTime() - `a`
+  let elapsed = (epochTime() - `a`) * 1000
   let elapsedStr = elapsed.formatFloat(format = ffDecimal, precision = 3)
   echo "$1 $2" % [benchmarkName, elapsedStr]
 
@@ -19,3 +19,13 @@ macro benchmark*(benchmarkName: static[string], code: untyped): untyped =
   result.add(getAst(finish(benchmarkName, a)))
   # echo repr(result)
 
+proc echoBenchmark*[T](benchmarkName: static[string], call: proc (): T): untyped =
+  if true:
+    var res: T.type
+    benchmark benchmarkName:
+      res = call()
+    echo res
+
+macro callBench*(a: untyped): untyped =
+  quote:
+    echoBenchmark(`a`.repr, `a`)

--- a/benchmarks/test.nim
+++ b/benchmarks/test.nim
@@ -1,39 +1,22 @@
-import zero_functional, strutils, sequtils, bench, times, os
+import zero_functional, strutils, bench, times, os
 
-var data = readFile("data.txt")
+let a = readFile("data.txt").split(" ") --> map(uint8(parseInt(it))) --> to(seq[uint8])
+let b = 0'u32..<2_000_000'u32 --> to(seq[uint32])
 
-let a = data.split(" ") --> map(parseInt(it)) --> to(seq[int])
-let b = (0..<2_000_000) --> to(seq[int])
-
-proc f(a: int, b: int): int =
-  a + b
-
+proc f(a: uint, b: uint): uint =
+  result = a + b
 
 proc example0: bool =
-  var n = zip(a, b) -->
-                map(f(it[0], it[1])).
-                filter(it mod 4 > 1).
-                map(it * 2).
-                all(it > 4)
-  result = n
+  result = zip(a, b) -->
+              map(f(it[0], it[1])).
+              filter((it mod 4'u) > 1'u).
+              map(it * 2'u8).
+              all(it > 4'u)
+callBench(example0)
 
-proc example1: bool =
-  var o = a -->
+proc example1: int =
+  result = a -->
             map(f(it, it)).
-            map(it - 7).
+            map(int(it) - 7).
             fold(0, it + a)
-  result = o > 0 # otherwise optimized
-
-
-var hack = false
-
-benchmark "example0":
-  hack = example0()
-    
-echo hack
-
-benchmark "example1":
-  hack = example1()
-
-echo hack
-
+callBench(example1)

--- a/benchmarks/test_sequtils.nim
+++ b/benchmarks/test_sequtils.nim
@@ -2,40 +2,30 @@ import strutils, sequtils, bench, times, os
 
 var data = readFile("data.txt")
 
-var a = data.split(" ").mapIt(parseInt(it))
+var a = data.split(" ").mapIt(uint8(parseInt(it)))
 
-var b: seq[int] = @[]
-for z in 0..<2_000_000:
+var b: seq[uint32] = @[]
+for z in 0'u32..<2_000_000'u32:
   b.add(z)
 
 
-proc f(a: int, b: int): int =
+proc f(a: uint, b: uint): uint =
   a + b
 
 
 proc example0: bool =
   var n = zip(a, b).
                 mapIt(f(it[0], it[1])).
-                filterIt(it mod 4 > 1).
-                mapIt(it * 2).
-                allIt(it > 4)
+                filterIt(it mod 4 > 1'u).
+                mapIt(it * 2'u).
+                allIt(it > 4'u)
   result = n
+callBench(example0)
 
-proc example1: bool =
+proc example1: int =
   var o = a.
             mapIt(f(it, it)).
-            mapIt(it - 7).
+            mapIt(int(it) - 7).
             foldl(b + a, 0)
-  result = o > 0 # otherwise optimized
-
-var hack = false
-
-benchmark "example0":
-  hack = example0()
-    
-echo hack
-
-benchmark "example1":
-  hack = example1()
-
-echo hack
+  result = o
+callBench(example1)

--- a/test.nim
+++ b/test.nim
@@ -354,9 +354,9 @@ suite "valid chains":
     let f2 = @[@["1","2","3"],@["4","5"],@["6"]]
     check((f2 --> flatten()) == @["1","2","3","4","5","6"])
     # indexedFlatten attaches the index of the element within the sub-list - that now has been flattened
-    check(f --> indexedFlatten() --> to(seq[(int,int)]) == @[(0,1),(1,2),(2,3),(0,4),(1,5),(0,6)])
+    check(f --> indexedFlatten()            == @[(0,1),(1,2),(2,3),(0,4),(1,5),(0,6)])
     # this is not the same as:
-    check(f --> flatten() --> map((idx,it)) ==             @[(0,1),(1,2),(2,3),(3,4),(4,5),(5,6)])
+    check(f --> flatten() --> map((idx,it)) == @[(0,1),(1,2),(2,3),(3,4),(4,5),(5,6)])
 
   test "flatten sum":
     check((@[a,b] --> flatten() --> fold(0, a + it)) == 9)

--- a/zero_functional.nim
+++ b/zero_functional.nim
@@ -318,12 +318,10 @@ proc createAutoProc(node: NimNode, isSeq: bool, resultType: string, td: string):
         let isIndexedFlatten = label == $Command.indexedFlatten
         if label == $Command.combinations: 
           hasCombination = true
-        elif label == $Command.map or label == $Command.zip or isIndexed or isFlatten: # zip is part of map and will not be checked
+        elif label == $Command.map or label == $Command.zip or isIndexed or isFlatten or isIndexedFlatten: # zip is part of map and will not be checked
           var params : NimNode = 
-            if isFlatten:
+            if isFlatten or isIndexedFlatten:
               nnkStmtList.newTree().add(newIdentNode(iteratorVariableName))
-            elif isIndexedFlatten:
-              nnkStmtList.newTree().add(newPar(newIdentNode(indexVariableName),newIdentNode(iteratorVariableName)))
             else:
               child[1].copyNimTree() # params of the map command
           # use / overwrite the last mapping to get the final result type


### PR DESCRIPTION
a small easter egg 🐰 🥚 

+ rework `zip`
   + zip also as 2nd, 3rd etc. command
   + better support for non-indexable types `[]`
   + performance should not be affected
   + `zip(a,b,c)` is now (roughly) translated to 
       `a --> filter(idx <= minHigh) --> map(a[idx], b[idx], c[idx])` - which makes `zip` now more regular in handling
+ rework `reduce`
   + easier subcommands added (add, product, min, max)
   + added "Idx" commands for `reduce` - e.g. `minIdx` to find the minimum element and its index
+ benchmark: use of uint (as is also done in rust code) --> (slightly) better performance - because `mod` can be optimized to `and` by C compiler
    + done same improvement to other nim file - performance here got much better (on my laptop) - but still not as good as zero-functional of course 😉 
    + also set timing output to msec