### PR TITLE
change `SEQUENCE_HANDLERS` to .compileTime. variable

### DIFF
--- a/zero_functional.nim
+++ b/zero_functional.nim
@@ -90,9 +90,8 @@ type
     b.add(T)
   
 
-static: 
-  ## Contains all functions that may result in a sequence result. Elements are added automatically to SEQUENCE_HANDLERS
-  var SEQUENCE_HANDLERS = [$Command.map, $Command.combinations, $Command.sub].toSet()
+## Contains all functions that may result in a sequence result. Elements are added automatically to SEQUENCE_HANDLERS
+var SEQUENCE_HANDLERS {.compileTime.} = [$Command.map, $Command.combinations, $Command.sub].toSet()
 
 ## Can be read in test implementation
 var lastFailure {.compileTime.} : string = "" 


### PR DESCRIPTION
Due to the recent change on Nim devel to make `static` open its own scope (https://github.com/nim-lang/Nim/pull/8108), zero-functional currently doesn't compile, due to the definition of the `SEQUENCE_HANDLERS` var in a `static` block.

I changed it to a `.compileTime.` var instead.